### PR TITLE
tokenize result section

### DIFF
--- a/src/pages/tokenize-submit/TokenizePreviewSubmit.tsx
+++ b/src/pages/tokenize-submit/TokenizePreviewSubmit.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import FormField from '../../components/Form'
+import HSButton from '../../components/HSButton'
+
+interface TokenizePreviewSubmitProps {
+  networkName: string
+  address: string
+  assetName: string
+  tokenName: string
+  tokenSymbol: string
+  pat: string
+  isDisabled: boolean
+  submit: () => {}
+}
+
+const TokenizePreviewSubmit: React.FC<TokenizePreviewSubmitProps> = ({
+  networkName,
+  address,
+  assetName,
+  tokenName,
+  tokenSymbol,
+  pat,
+  isDisabled,
+  submit
+}) => {
+  return (
+    <div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-sm">
+        <FormField
+          label="Network"
+          id="network"
+          value={networkName}
+          placeholder="Please Connect Wallet"
+          disabled
+          required
+        />
+        <FormField
+          label="Your Wallet Address"
+          id="address"
+          value={address}
+          placeholder="Please Connect Wallet"
+          disabled
+          required
+        />
+        <FormField
+          label="GitHub Repository Name"
+          placeholder="owner_name/repository_name"
+          id="repoName"
+          value={assetName}
+          disabled
+          required
+        />
+        <FormField label="Token Name" id="tokenName" value={tokenName} required disabled />
+        <FormField label="Token Symbol" id="tokenSymbol" value={tokenSymbol} required disabled />
+        <FormField label="Personal Access Token" id="pac" value={pat} required disabled />
+        <FormField label="Supply" id="supply" value="10,000,000" required disabled />
+        <FormField label="Dev Protocol Treasury Fee" id="fee" value="500,000" required disabled>
+          <div className="flex text-sm">
+            <span>What is the </span>
+            <a
+              href="https://initto.devprotocol.xyz/en/what-is-treasury/"
+              target="_blank"
+              className="ml-1 text-link"
+              rel="noreferrer"
+            >
+              Dev Protocol Treasury Fee?
+            </a>
+          </div>
+        </FormField>
+      </div>
+
+      <div className="float-right flex flex-col items-end">
+        <HSButton context="submit" type="filled" isDisabled={isDisabled} onClick={submit}>
+          Sign and submit
+        </HSButton>
+      </div>
+    </div>
+  )
+}
+
+export default TokenizePreviewSubmit

--- a/src/pages/tokenize-submit/TokenizeResult.tsx
+++ b/src/pages/tokenize-submit/TokenizeResult.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import HSButton from '../../components/HSButton'
+import { SectionLoading } from '../../components/Spinner'
+import { Market } from '../../const'
+
+interface TokenizeResultProps {
+  isLoading: boolean
+  errorMessage?: string
+  newPropertyAddress?: string
+  market?: Market
+}
+
+const TokenizeResult: React.FC<TokenizeResultProps> = ({ isLoading, errorMessage, newPropertyAddress, market }) => {
+  return (
+    <>
+      {isLoading && <SectionLoading />}
+      {!isLoading && (
+        <>
+          {newPropertyAddress && (
+            <div>
+              <h2 className="w-full mb-sm text-2xl">Tokenization Success</h2>
+              <div className="flex flex-col sm:flex-row justify-between">
+                <div className="flex flex-col">
+                  <h3>Your Token</h3>
+                  <span>{newPropertyAddress}</span>
+                </div>
+                <HSButton link={`/properties/${newPropertyAddress}`} type="filled" label="View Your Token" />
+              </div>
+            </div>
+          )}
+          {!newPropertyAddress && (
+            <div>
+              <h2 className="w-full mb-sm text-2xl">Tokenization Error</h2>
+              <div className="flex justify-between">
+                <span>{errorMessage ?? `Error tokenizing ${market} property`}</span>
+                <HSButton
+                  link={`/tokenize/${market ? market.toLowerCase() : ''}`}
+                  type="filled"
+                  label="Back to Tokenization"
+                />
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+export default TokenizeResult

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -83,6 +83,7 @@ export const mapProviderToDevContracts = async (provider: ethers.providers.BaseP
 
 type MarketAddressOptions = {
   github: string
+  youtube: string
 }
 
 export const getNetworkMarketAddresses = async (


### PR DESCRIPTION
## Proposed Changes
Add a more robust Tokenize Result section

## Implementation
Separates out some components TokenizePreviewSubmit (the preview form) and TokenizeResult (which is based on the Figma mocks)
