### PR TITLE
joins properties into nested routes; shares propertyDetails data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Home from './pages/home'
 import UserPropertiesListPage from './pages/user-properties-list'
 import UserPositionsListPage from './pages/user-positions-list'
 import GrowthPage from './pages/growth'
-import PropertyPage from './pages/property'
+import PropertyOverviewPage from './pages/properties/property-overview'
 import TokenizeMarketSelect from './pages/tokenize-market-select'
 import TokenizeFormPage from './pages/tokenize-form'
 import TokenizeSubmit from './pages/tokenize-submit'
@@ -24,7 +24,8 @@ import MarkdownPage from './pages/markdown-page'
 import { ReactComponent as PrivacyPolicy } from '../PRIVACY-POLICY.md'
 import { ReactComponent as TermsAndConditions } from '../TERMS-AND-CONDITIONS.md'
 import Footer from './components/Footer'
-import PropertyHoldersPage from './pages/property-holders'
+import PropertyHoldersPage from './pages/properties/property-holders'
+import PropertyOutlet from './pages/properties'
 
 function App() {
   const walletProviderContext = useWalletProviderContext()
@@ -70,9 +71,12 @@ function App() {
                         <Route path="/" element={<Home />} />
                         <Route path="/:userAddress" element={<UserPropertiesListPage />} />
                         <Route path="/:userAddress/positions" element={<UserPositionsListPage />} />
+
+                        <Route path="/properties/:hash" element={<PropertyOutlet />}>
+                          <Route index element={<PropertyOverviewPage />} />
+                          <Route path="holders" element={<PropertyHoldersPage />} />
+                        </Route>
                         <Route path="/properties/:hash/stake" element={<StakePage />} />
-                        <Route path="/properties/:hash" element={<PropertyPage />} />
-                        <Route path="/properties/:hash/holders" element={<PropertyHoldersPage />} />
                         <Route path="/growth" element={<GrowthPage />} />
                         <Route path="/tokenize" element={<TokenizeMarketSelect />} />
                         <Route path="/tokenize/:market" element={<TokenizeFormPage />} />

--- a/src/components/NavTabs/index.tsx
+++ b/src/components/NavTabs/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 
 interface NavTabsProps {}
 
@@ -10,16 +10,18 @@ export const NavTabs: React.FC<NavTabsProps> = ({ children }) => {
 interface NavTabItemProps {
   title: string
   path: string
-  isActive: boolean
 }
 
-export const NavTabItem: React.FC<NavTabItemProps> = ({ title, path, isActive }) => {
+export const NavTabItem: React.FC<NavTabItemProps> = ({ title, path }) => {
   return (
-    <Link
-      className={`mr-sm rounded px-sm py-1 ${isActive ? 'bg-black from-primary to-secondary text-white' : 'bg-white'}`}
+    <NavLink
+      end
+      className={({ isActive }) =>
+        `mr-sm rounded px-sm py-1 shadow ${isActive ? `bg-black from-primary to-secondary text-white` : 'bg-white'}`
+      }
       to={path}
     >
       {title}
-    </Link>
+    </NavLink>
   )
 }

--- a/src/pages/properties/ProperySummary/index.tsx
+++ b/src/pages/properties/ProperySummary/index.tsx
@@ -1,18 +1,17 @@
 import React from 'react'
 import { FaExternalLinkAlt, FaGithub, FaQuestionCircle, FaYoutube } from 'react-icons/fa'
-import { Market } from '../../const'
-import { PropertyDetails } from '../../hooks/usePropertyDetails'
-import { crunchAddress, deployedNetworkToReadable, getExplorerUrl } from '../../utils/utils'
-import DPLTitleBar from '../DPLTitleBar'
-import { NavTabItem, NavTabs } from '../NavTabs'
+import { Market } from '../../../const'
+import { PropertyDetails } from '../../../hooks/usePropertyDetails'
+import { crunchAddress, deployedNetworkToReadable, getExplorerUrl } from '../../../utils/utils'
+import DPLTitleBar from '../../../components/DPLTitleBar'
+import { NavTabItem, NavTabs } from '../../../components/NavTabs'
 
 interface PropertySummaryHeadProps {
   propertyDetails: PropertyDetails
   hash: string
-  isActive: 'details' | 'holders'
 }
 
-const PropertySummaryHead: React.FC<PropertySummaryHeadProps> = ({ propertyDetails, hash, isActive }) => {
+const PropertySummaryHead: React.FC<PropertySummaryHeadProps> = ({ propertyDetails, hash }) => {
   return (
     <>
       <div className="flex items-center justify-between">
@@ -55,8 +54,8 @@ const PropertySummaryHead: React.FC<PropertySummaryHeadProps> = ({ propertyDetai
         </a>
       </div>
       <NavTabs>
-        <NavTabItem title="Details" isActive={isActive === 'details'} path={`/properties/${hash}`} />
-        <NavTabItem title="Holders" isActive={isActive === 'holders'} path={`/properties/${hash}/holders`} />
+        <NavTabItem title="Details" path={`/properties/${hash}`} />
+        <NavTabItem title="Holders" path={`/properties/${hash}/holders`} />
       </NavTabs>
     </>
   )

--- a/src/pages/properties/index.tsx
+++ b/src/pages/properties/index.tsx
@@ -1,0 +1,43 @@
+import { UndefinedOr } from '@devprotocol/util-ts'
+import React from 'react'
+import { Outlet, useOutletContext, useParams } from 'react-router-dom'
+import Card from '../../components/Card'
+import PropertySummaryHead from './ProperySummary'
+import { SectionLoading } from '../../components/Spinner'
+import { PropertyDetails, usePropertyDetails } from '../../hooks/usePropertyDetails'
+
+interface PropertyOutletProps {}
+
+type ContextType = {
+  propertyDetails: PropertyDetails | null
+  isPropertyDetailsLoading: boolean
+  propertyDetailsError: UndefinedOr<String>
+}
+
+export function usePropertyOutlet() {
+  return useOutletContext<ContextType>()
+}
+
+const PropertyOutlet: React.FC<PropertyOutletProps> = () => {
+  const { hash } = useParams()
+  const { propertyDetails, isLoading, error } = usePropertyDetails(hash)
+
+  return (
+    <div>
+      {hash && propertyDetails && !isLoading && (
+        <>
+          <PropertySummaryHead propertyDetails={propertyDetails} hash={hash} isActive="details" />
+          <Outlet context={{ propertyDetails, isPropertyDetailsLoading: isLoading, propertyDetailsError: error }} />
+        </>
+      )}
+      {isLoading && <SectionLoading />}
+      {error && (
+        <Card>
+          <div className="text-red-500">{error}</div>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default PropertyOutlet

--- a/src/pages/properties/index.tsx
+++ b/src/pages/properties/index.tsx
@@ -26,7 +26,7 @@ const PropertyOutlet: React.FC<PropertyOutletProps> = () => {
     <div>
       {hash && propertyDetails && !isLoading && (
         <>
-          <PropertySummaryHead propertyDetails={propertyDetails} hash={hash} isActive="details" />
+          <PropertySummaryHead propertyDetails={propertyDetails} hash={hash} />
           <Outlet context={{ propertyDetails, isPropertyDetailsLoading: isLoading, propertyDetailsError: error }} />
         </>
       )}

--- a/src/pages/properties/property-holders/index.tsx
+++ b/src/pages/properties/property-holders/index.tsx
@@ -1,19 +1,18 @@
 import React, { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import Card from '../../components/Card'
-import Detail from '../../components/Detail'
-import PropertySummaryHead from '../../components/ProperySummary'
-import { SectionLoading } from '../../components/Spinner'
-import { usePropertyBalances } from '../../hooks/usePropertyBalances'
-import { usePropertyDetails } from '../../hooks/usePropertyDetails'
-import { crunchAddress, toDisplayAmount } from '../../utils/utils'
+import Card from '../../../components/Card'
+import Detail from '../../../components/Detail'
+import { SectionLoading } from '../../../components/Spinner'
+import { usePropertyBalances } from '../../../hooks/usePropertyBalances'
+import { crunchAddress, toDisplayAmount } from '../../../utils/utils'
+import { usePropertyOutlet } from '..'
 
 interface PropertyHoldersPageProps {}
 
 const PropertyHoldersPage: React.FC<PropertyHoldersPageProps> = () => {
   const { hash } = useParams()
   const { propertyBalances, error: balancesError } = usePropertyBalances(hash)
-  const { propertyDetails, isLoading, error: detailsError } = usePropertyDetails(hash)
+  const { propertyDetails, isPropertyDetailsLoading, propertyDetailsError } = usePropertyOutlet()
   const [sortedBalances, setSortedBalances] = useState<{ account: string; balance: string }[]>()
 
   useEffect(() => {
@@ -26,9 +25,8 @@ const PropertyHoldersPage: React.FC<PropertyHoldersPageProps> = () => {
 
   return (
     <>
-      {propertyDetails && hash && !isLoading && (
+      {propertyDetails && !isPropertyDetailsLoading && (
         <div>
-          <PropertySummaryHead propertyDetails={propertyDetails} hash={hash} isActive="holders" />
           {sortedBalances && sortedBalances.length > 0 && (
             <div className="grid grid-cols-2 gap-sm">
               {sortedBalances.map(pb => (
@@ -50,9 +48,9 @@ const PropertyHoldersPage: React.FC<PropertyHoldersPageProps> = () => {
           )}
         </div>
       )}
-      {isLoading && <SectionLoading />}
+      {isPropertyDetailsLoading && <SectionLoading />}
       {balancesError && <span>{balancesError}</span>}
-      {detailsError && <span>{detailsError}</span>}
+      {propertyDetailsError && <span>{propertyDetailsError}</span>}
     </>
   )
 }

--- a/src/pages/properties/property-overview/StakeOption.tsx
+++ b/src/pages/properties/property-overview/StakeOption.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
-import Card from '../../components/Card'
-import { isNumberInput } from '../../utils/utils'
+import Card from '../../../components/Card'
+import { isNumberInput } from '../../../utils/utils'
 
 interface StakeOptionProps {
   optionName: string

--- a/src/pages/properties/property-overview/fetch-token-data.hook.tsx
+++ b/src/pages/properties/property-overview/fetch-token-data.hook.tsx
@@ -1,8 +1,8 @@
 import { whenDefinedAll } from '@devprotocol/util-ts'
 import useSWR from 'swr'
-import { SWRCachePath } from '../../const/cache-path'
-import { useProvider } from '../../context/walletContext'
-import { getPropertyData } from '../../utils/utils'
+import { SWRCachePath } from '../../../const/cache-path'
+import { useProvider } from '../../../context/walletContext'
+import { getPropertyData } from '../../../utils/utils'
 
 export const usePropertyData = (propertyAddress?: string) => {
   const { nonConnectedEthersProvider } = useProvider()

--- a/src/pages/properties/property-overview/index.tsx
+++ b/src/pages/properties/property-overview/index.tsx
@@ -1,23 +1,16 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
-import DPLTitleBar from '../../components/DPLTitleBar'
-import { FaQuestionCircle, FaGithub, FaExternalLinkAlt, FaYoutube } from 'react-icons/fa'
-import { Market } from '../../const'
-import { usePropertyDetails } from '../../hooks/usePropertyDetails'
 import StakeOption from './StakeOption'
-import HowItWorks from '../../components/HowItWorks'
-import { crunchAddress, deployedNetworkToReadable, getExplorerUrl } from '../../utils/utils'
-import { SectionLoading } from '../../components/Spinner'
-import { DPLHr } from '../../components/DPLHr'
-import { TweetLarge } from '../../components/Tweet'
-import { NavTabItem, NavTabs } from '../../components/NavTabs'
-import PropertySummary from '../../components/ProperySummary'
+import HowItWorks from '../../../components/HowItWorks'
+import { DPLHr } from '../../../components/DPLHr'
+import { TweetLarge } from '../../../components/Tweet'
+import { usePropertyOutlet } from '..'
 
 interface TokenProps {}
 
-const PropertyPage: React.FC<TokenProps> = () => {
+const PropertyOverviewPage: React.FC<TokenProps> = () => {
   const { hash } = useParams()
-  const { propertyDetails, isLoading, error } = usePropertyDetails(hash)
+  const { propertyDetails, propertyDetailsError } = usePropertyOutlet()
   const options = [
     {
       amount: 10,
@@ -42,10 +35,8 @@ const PropertyPage: React.FC<TokenProps> = () => {
 
   return (
     <div>
-      {propertyDetails && hash && !isLoading && (
+      {propertyDetails && hash && (
         <>
-          <PropertySummary propertyDetails={propertyDetails} hash={hash} isActive="details" />
-
           <div className="mb-24 grid grid-cols-1 gap-sm sm:grid-cols-2">
             {hash &&
               options.map(option => (
@@ -74,11 +65,9 @@ const PropertyPage: React.FC<TokenProps> = () => {
         </>
       )}
 
-      {isLoading && <SectionLoading />}
-
-      {error && <div className="text-red-500">{error}</div>}
+      {propertyDetailsError && <div className="text-red-500">{propertyDetailsError}</div>}
     </div>
   )
 }
 
-export default PropertyPage
+export default PropertyOverviewPage

--- a/src/pages/user-positions-list/index.tsx
+++ b/src/pages/user-positions-list/index.tsx
@@ -43,8 +43,8 @@ const UserPositionsListPage: React.FC<UserPositionsListPageProps> = () => {
       <BackButton title="Home" path="/" />
       <DPLTitleBar className="mb-sm" title={`Address: ${userAddress ? crunchAddress(userAddress) : ''}`} />
       <NavTabs>
-        <NavTabItem title="Properties" isActive={false} path={`/${userAddress}`} />
-        <NavTabItem title="Positions" isActive={true} path={`#`} />
+        <NavTabItem title="Properties" path={`/${userAddress}`} />
+        <NavTabItem title="Positions" path={`#`} />
       </NavTabs>
       <div>
         {!isLoading && (

--- a/src/pages/user-properties-list/index.tsx
+++ b/src/pages/user-properties-list/index.tsx
@@ -23,8 +23,8 @@ const UserPropertiesListPage: React.FC<UserPropertiesListPageProps> = () => {
       <BackButton title="Home" path="/" />
       <DPLTitleBar className="mb-sm" title={`Address: ${userAddress ? crunchAddress(userAddress) : ''}`} />
       <NavTabs>
-        <NavTabItem title="Properties" isActive={true} path={`#`} />
-        <NavTabItem title="Positions" isActive={false} path={`/${userAddress}/positions`} />
+        <NavTabItem title="Properties" path={`#`} />
+        <NavTabItem title="Positions" path={`/${userAddress}/positions`} />
       </NavTabs>
 
       <div>


### PR DESCRIPTION
## Proposed Changes
Nest property routes and share propertyDetails data to improve load time and user experience

## Implementation
- Moves `holders` and `overview` into properties folder
- Creates an PropertyOutlet component which fetches property details and shares it in a context
- Uses NavLink instead of Link for nav tabs
