### PR TITLE
allows stake page to inherit property context for faster loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useWalletProviderContext, WalletContext } from './context/walletContext
 import { TokenizeProvider } from './context/tokenizeContext'
 
 import PageNotFound from './pages/errors/404'
-import StakePage from './pages/stake'
+import StakePage from './pages/properties/stake'
 import NetworkSelectPage from './pages/network-select'
 import { Background } from './components/Background'
 import WaitMarketPage from './pages/wait-market'
@@ -26,6 +26,7 @@ import { ReactComponent as TermsAndConditions } from '../TERMS-AND-CONDITIONS.md
 import Footer from './components/Footer'
 import PropertyHoldersPage from './pages/properties/property-holders'
 import PropertyOutlet from './pages/properties'
+import PropertyTabsContainer from './pages/properties/PropertyTabsContainer'
 
 function App() {
   const walletProviderContext = useWalletProviderContext()
@@ -73,10 +74,12 @@ function App() {
                         <Route path="/:userAddress/positions" element={<UserPositionsListPage />} />
 
                         <Route path="/properties/:hash" element={<PropertyOutlet />}>
-                          <Route index element={<PropertyOverviewPage />} />
-                          <Route path="holders" element={<PropertyHoldersPage />} />
+                          <Route path="/properties/:hash/stake" element={<StakePage />} />
+                          <Route path="" element={<PropertyTabsContainer />}>
+                            <Route index element={<PropertyOverviewPage />} />
+                            <Route path="holders" element={<PropertyHoldersPage />} />
+                          </Route>
                         </Route>
-                        <Route path="/properties/:hash/stake" element={<StakePage />} />
                         <Route path="/growth" element={<GrowthPage />} />
                         <Route path="/tokenize" element={<TokenizeMarketSelect />} />
                         <Route path="/tokenize/:market" element={<TokenizeFormPage />} />

--- a/src/components/ConnectButton/index.tsx
+++ b/src/components/ConnectButton/index.tsx
@@ -80,9 +80,9 @@ const ConnectButton: React.FC<ConnectButtonParams> = () => {
               </div>
             )}
             {!isValidConnectedNetwork && (
-              <div className="align-center flex">
-                <FaExclamationTriangle className="text-danger-400" />
-                <div className="text-danger-400 ml-xs">
+              <div className="flex items-center">
+                <FaExclamationTriangle className="text-red-400" />
+                <div className="text-danger-400 ml-1">
                   Connect Wallet to <span className="uppercase">{deployedNetworkToReadable()}</span>
                 </div>
               </div>

--- a/src/pages/properties/PropertyTabsContainer/index.tsx
+++ b/src/pages/properties/PropertyTabsContainer/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Outlet, useParams } from 'react-router-dom'
+import { usePropertyDetails } from '../../../hooks/usePropertyDetails'
+import PropertySummaryHead from '../ProperySummary'
+
+interface PropertyTabsContainerProps {}
+
+const PropertyTabsContainer: React.FC<PropertyTabsContainerProps> = () => {
+  const { hash } = useParams()
+  const { propertyDetails, isLoading, error } = usePropertyDetails(hash)
+  return (
+    <>
+      {' '}
+      {hash && propertyDetails && !isLoading && (
+        <>
+          <PropertySummaryHead propertyDetails={propertyDetails} hash={hash} />
+          <Outlet context={{ propertyDetails, isPropertyDetailsLoading: isLoading, propertyDetailsError: error }} />
+        </>
+      )}
+    </>
+  )
+}
+
+export default PropertyTabsContainer

--- a/src/pages/properties/index.tsx
+++ b/src/pages/properties/index.tsx
@@ -2,7 +2,6 @@ import { UndefinedOr } from '@devprotocol/util-ts'
 import React from 'react'
 import { Outlet, useOutletContext, useParams } from 'react-router-dom'
 import Card from '../../components/Card'
-import PropertySummaryHead from './ProperySummary'
 import { SectionLoading } from '../../components/Spinner'
 import { PropertyDetails, usePropertyDetails } from '../../hooks/usePropertyDetails'
 
@@ -26,7 +25,6 @@ const PropertyOutlet: React.FC<PropertyOutletProps> = () => {
     <div>
       {hash && propertyDetails && !isLoading && (
         <>
-          <PropertySummaryHead propertyDetails={propertyDetails} hash={hash} />
           <Outlet context={{ propertyDetails, isPropertyDetailsLoading: isLoading, propertyDetailsError: error }} />
         </>
       )}

--- a/src/pages/properties/stake/StakeStep.tsx
+++ b/src/pages/properties/stake/StakeStep.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FaCheck } from 'react-icons/fa'
-import HSButton from '../../components/HSButton'
+import HSButton from '../../../components/HSButton'
 
 interface StakeStepProps {
   isComplete: boolean

--- a/src/pages/properties/stake/index.tsx
+++ b/src/pages/properties/stake/index.tsx
@@ -3,18 +3,18 @@ import { BigNumber, constants, utils } from 'ethers'
 import React, { useEffect, useState } from 'react'
 import { FaExclamationTriangle } from 'react-icons/fa'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
-import BackButton from '../../components/BackButton'
-import Card from '../../components/Card'
-import { DPLHr } from '../../components/DPLHr'
-import DPLTitleBar from '../../components/DPLTitleBar'
-import HowItWorks from '../../components/HowItWorks'
-import { SectionLoading } from '../../components/Spinner'
-import { ERROR_MSG } from '../../const'
-import { useProvider } from '../../context/walletContext'
-import { useDevAllowance } from '../../hooks/useAllowance'
-import { useDevApprove } from '../../hooks/useApprove'
-import { usePropertyDetails } from '../../hooks/usePropertyDetails'
-import { isNumberInput, mapProviderToDevContracts } from '../../utils/utils'
+import BackButton from '../../../components/BackButton'
+import Card from '../../../components/Card'
+import { DPLHr } from '../../../components/DPLHr'
+import DPLTitleBar from '../../../components/DPLTitleBar'
+import HowItWorks from '../../../components/HowItWorks'
+import { SectionLoading } from '../../../components/Spinner'
+import { ERROR_MSG } from '../../../const'
+import { useProvider } from '../../../context/walletContext'
+import { useDevAllowance } from '../../../hooks/useAllowance'
+import { useDevApprove } from '../../../hooks/useApprove'
+import { usePropertyDetails } from '../../../hooks/usePropertyDetails'
+import { isNumberInput, mapProviderToDevContracts } from '../../../utils/utils'
 import StakeStep from './StakeStep'
 import { useLockup } from './useLockup'
 
@@ -22,10 +22,8 @@ interface StakePageProps {}
 
 const StakePage: React.FC<StakePageProps> = () => {
   const [searchParams] = useSearchParams()
-  const { hash } = useParams()
   const [amount, setAmount] = useState(0)
   const [error, setError] = useState<UndefinedOr<string>>()
-  const { propertyDetails, isLoading, error: propertyDetailsError } = usePropertyDetails(hash)
   const { ethersProvider, isValidConnectedNetwork } = useProvider()
   const { lockup, isLoading: lockupLoading } = useLockup()
   const [isStakingComplete, setIsStakingComplete] = useState(false)
@@ -34,6 +32,9 @@ const StakePage: React.FC<StakePageProps> = () => {
   const { approve, isLoading: approveIsLoading, error: approveError } = useDevApprove()
   const [allowance, setAllowance] = useState<UndefinedOr<BigNumber>>()
   const navigate = useNavigate()
+
+  const { hash } = useParams()
+  const { propertyDetails, isLoading, error: propertyDetailsError } = usePropertyDetails(hash)
 
   useEffect(() => {
     if (!ethersProvider) {
@@ -111,12 +112,12 @@ const StakePage: React.FC<StakePageProps> = () => {
 
   return (
     <>
-      {!isLoading && propertyDetails && (
+      {propertyDetails && (
         <div>
           <BackButton title="Back" path={`/properties/${hash}`} />
           <DPLTitleBar title={`Stake ${amount} on ${propertyDetails.propertyName}`} className="mb-md" />
           <div className="mb-md flex w-full">
-            {!ethersProvider && (
+            {(!ethersProvider || !isValidConnectedNetwork) && (
               <div className="my-lg w-full">
                 <Card isDisabled={true}>
                   <div className="my-lg flex items-center justify-center py-lg">
@@ -126,7 +127,7 @@ const StakePage: React.FC<StakePageProps> = () => {
                 </Card>
               </div>
             )}
-            {ethersProvider && (
+            {ethersProvider && isValidConnectedNetwork && (
               <div className="grid gap-24">
                 <StakeStep
                   name="Approve"

--- a/src/pages/properties/stake/useLockup.ts
+++ b/src/pages/properties/stake/useLockup.ts
@@ -1,8 +1,8 @@
 import { UndefinedOr } from '@devprotocol/util-ts'
 import { BigNumber, providers } from 'ethers'
 import { useCallback, useState } from 'react'
-import { ERROR_MSG } from '../../const'
-import { useProvider } from '../../context/walletContext'
+import { ERROR_MSG } from '../../../const'
+import { useProvider } from '../../../context/walletContext'
 import { positionsCreate } from '@devprotocol/dev-kit/agent'
 
 export const lockup = async ({


### PR DESCRIPTION
## Proposed Changes
Moves Stake Page inside of the Property Outlet to allow for faster loading time

## Implementation
- Adds a PropertyTabsContainer to persist the header + tabs in Details and Holder
- Moves Stake page into the Property Route and uses that context for faster loading
- Small styling corrections for invalid network connection
