### PR TITLE
resets form on market select

### DIFF
--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -15,6 +15,10 @@ export const ERROR_MSG = {
   no_property_address: 'No property address found'
 } as const
 
+export const FORM_HINT = {
+  symbol_length: 'Symbol should be 3 to 4 characters long (for example DEV)'
+} as const
+
 export const DEPLOYMENTS = {
   arbitrum_rinkeby: 'https://arbitrum-rinkeby.niwa.xyz',
   arbitrum_one: 'https://arbitrum.niwa.xyz',

--- a/src/context/tokenizeContext.tsx
+++ b/src/context/tokenizeContext.tsx
@@ -24,6 +24,7 @@ export type ITokenize = {
   validateForm: () => void
   agreedToTerms: boolean
   setAgreedToTerms: Dispatch<SetStateAction<boolean>>
+  reset: () => void
 }
 
 const tokenize: ITokenize = {
@@ -43,7 +44,8 @@ const tokenize: ITokenize = {
   setAddress: () => {},
   validateForm: () => {},
   agreedToTerms: false,
-  setAgreedToTerms: () => {}
+  setAgreedToTerms: () => {},
+  reset: () => {}
 }
 
 export const TokenizeContext = React.createContext(tokenize)
@@ -117,6 +119,15 @@ export const TokenizeProvider: React.FC = ({ children }) => {
 
   useEffect(() => validateForm(), [assetName, tokenName, tokenSymbol, personalAccessToken, validateForm])
 
+  const reset = () => {
+    setAssetName('')
+    setTokenName('')
+    setTokenSymbol('')
+    setPersonalAccessToken('')
+    setIsValid(false)
+    setAgreedToTerms(false)
+  }
+
   return (
     <TokenizeContext.Provider
       value={{
@@ -136,7 +147,8 @@ export const TokenizeProvider: React.FC = ({ children }) => {
         setAddress,
         validateForm,
         agreedToTerms,
-        setAgreedToTerms
+        setAgreedToTerms,
+        reset
       }}
     >
       {children}

--- a/src/pages/tokenize-form/DiscordForm.tsx
+++ b/src/pages/tokenize-form/DiscordForm.tsx
@@ -4,6 +4,7 @@ import FormField from '../../components/Form'
 import { TokenizeContext } from '../../context/tokenizeContext'
 import HSButton from '../../components/HSButton'
 import TermsCheckBox from './TermsCheckBox'
+import { FORM_HINT } from '../../const'
 
 interface DiscordFormProps {}
 
@@ -83,7 +84,7 @@ const DiscordForm: FunctionComponent<DiscordFormProps> = () => {
                 }
               }}
             >
-              <span className="text-sm">Symbol should be 3 to 4 characters long (for example DEV)</span>
+              <span className="text-sm">{FORM_HINT.symbol_length}</span>
             </FormField>
           </div>
           <TermsCheckBox isChecked={agreedToTerms} setAgreedToTerms={async () => setAgreedToTerms(val => !val)} />

--- a/src/pages/tokenize-form/GithubForm.tsx
+++ b/src/pages/tokenize-form/GithubForm.tsx
@@ -5,6 +5,7 @@ import { TokenizeContext } from '../../context/tokenizeContext'
 import HSButton from '../../components/HSButton'
 import { isValidNetwork } from '../../utils/utils'
 import TermsCheckBox from './TermsCheckBox'
+import { FORM_HINT } from '../../const'
 
 interface GithubFormProps {}
 
@@ -83,7 +84,7 @@ const GithubForm: FunctionComponent<GithubFormProps> = () => {
             }
           }}
         >
-          <span className="text-sm">Symbol should be 3 to 4 characters long (for example DEV)</span>
+          <span className="text-sm">{FORM_HINT.symbol_length}</span>
         </FormField>
         <div>
           <FormField

--- a/src/pages/tokenize-form/YouTubeForm.tsx
+++ b/src/pages/tokenize-form/YouTubeForm.tsx
@@ -5,6 +5,7 @@ import { TokenizeContext } from '../../context/tokenizeContext'
 import HSButton from '../../components/HSButton'
 import TermsCheckBox from './TermsCheckBox'
 import gLogo from '../../img/g-logo.png'
+import { FORM_HINT } from '../../const'
 
 interface YouTubeFormProps {}
 
@@ -86,7 +87,7 @@ const YouTubeForm: FunctionComponent<YouTubeFormProps> = () => {
                 }
               }}
             >
-              <span className="text-sm">Symbol should be 3 to 4 characters long (for example DEV)</span>
+              <span className="text-sm">{FORM_HINT.symbol_length}</span>
             </FormField>
           </div>
           <TermsCheckBox isChecked={agreedToTerms} setAgreedToTerms={async () => setAgreedToTerms(val => !val)} />

--- a/src/pages/tokenize-market-select/index.tsx
+++ b/src/pages/tokenize-market-select/index.tsx
@@ -1,13 +1,20 @@
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useContext, useEffect } from 'react'
 import BackButton from '../../components/BackButton'
 import DPLTitleBar from '../../components/DPLTitleBar'
 import TokenizeLink from './TokenizeLink'
 import { FaDiscord, FaGithub, FaLightbulb, FaTwitter, FaYoutube } from 'react-icons/fa'
 import TitleSubSection from '../../components/TitleSubSection'
+import { TokenizeContext } from '../../context/tokenizeContext'
 
 interface TokenizeMarketSelectProps {}
 
 const TokenizeMarketSelect: FunctionComponent<TokenizeMarketSelectProps> = () => {
+  const { reset } = useContext(TokenizeContext)
+
+  useEffect(() => {
+    reset()
+  }, [reset])
+
   return (
     <div>
       <BackButton title="Home" path="/" />


### PR DESCRIPTION
## Proposed Changes
Reset form data on market select. Related to bug #146 

## Implementation
Adds a `reset` to TokenizeContext, which is fired on market select load

closes #146 