### PR TITLE
add to wallet list button added to property section header

### DIFF
--- a/src/components/HSButton/index.tsx
+++ b/src/components/HSButton/index.tsx
@@ -27,10 +27,12 @@ const HSButton: React.FC<HSButtonProps> = ({
     switch (type) {
       case 'filled':
         return 'bg-black'
-      case 'outlined':
       case 'danger':
       case 'success':
         return 'bg-white'
+
+      case 'outlined':
+        return 'transparent'
 
       default:
         return 'bg-blue-500'
@@ -56,7 +58,7 @@ const HSButton: React.FC<HSButtonProps> = ({
   const assertBorder = (type: ButtonStyle) => {
     switch (type) {
       case 'outlined':
-        return 'border-blue-500'
+        return 'border-blue-400 border-2 hover:border-blue-700'
       case 'danger':
         return 'border-red-500'
       case 'success':
@@ -75,7 +77,7 @@ const HSButton: React.FC<HSButtonProps> = ({
 
   const ButtonBase = (
     <button
-      className={`${btnStyles.background} ${btnStyles.text} ${btnStyles.border} rounded border px-4 py-2 ${
+      className={`${btnStyles.background} ${btnStyles.text} ${btnStyles.border} rounded border px-4 py-2 shadow ${
         isDisabled ? 'opacity-50' : ''
       }`}
       role="button"

--- a/src/hooks/useAddToWalletList.ts
+++ b/src/hooks/useAddToWalletList.ts
@@ -1,0 +1,32 @@
+import { UndefinedOr } from '@devprotocol/util-ts'
+import { useState } from 'react'
+import { isError } from '../utils/utils'
+
+export const useAddToWalletList = () => {
+  const [error, setError] = useState<UndefinedOr<string>>()
+  const callback = async (tokenSymbol: string, newPropertyAddress: string) => {
+    const tokenDecimals = 18
+
+    try {
+      if (!window.ethereum) {
+        return
+      }
+
+      window.ethereum.request({
+        method: 'wallet_watchAsset',
+        params: {
+          type: 'ERC20', // Initially only supports ERC20, but eventually more!
+          options: {
+            address: newPropertyAddress, // The address that the token is at.
+            symbol: tokenSymbol, // A ticker symbol or shorthand, up to 5 chars.
+            decimals: tokenDecimals // The number of decimals in the token
+          }
+        }
+      })
+    } catch (error) {
+      console.log(error)
+      setError(isError(error) ? error.message : `${error}`)
+    }
+  }
+  return { addToWalletList: callback, error }
+}

--- a/src/pages/properties/ProperySummary/index.tsx
+++ b/src/pages/properties/ProperySummary/index.tsx
@@ -6,6 +6,8 @@ import { crunchAddress, deployedNetworkToReadable, getExplorerUrl } from '../../
 import DPLTitleBar from '../../../components/DPLTitleBar'
 import { NavTabItem, NavTabs } from '../../../components/NavTabs'
 import CopyButton from '../../../components/CopyButton'
+import HSButton from '../../../components/HSButton'
+import { useAddToWalletList } from '../../../hooks/useAddToWalletList'
 
 interface PropertySummaryHeadProps {
   propertyDetails: PropertyDetails
@@ -13,11 +15,19 @@ interface PropertySummaryHeadProps {
 }
 
 const PropertySummaryHead: React.FC<PropertySummaryHeadProps> = ({ propertyDetails, hash }) => {
+  const { addToWalletList } = useAddToWalletList()
+
+  const addToUserWallet = () => {
+    addToWalletList(propertyDetails.propertySymbol, hash)
+  }
+
   return (
     <>
-      <div className="flex items-center justify-between">
+      <div className="mb-2 flex items-center justify-between">
         <DPLTitleBar title={propertyDetails?.propertySymbol ?? ''} />
-        {/* <FaShareAlt color="lightgray" /> */}
+        <HSButton type="outlined" onClick={addToUserWallet}>
+          <span className="text-sm">+ Add To Wallet List</span>
+        </HSButton>
       </div>
       <div className="items-align flex">
         <span className="mr-1 text-sm font-bold text-gray-400">{hash}</span>

--- a/src/pages/tokenize-submit/TokenizeResult.tsx
+++ b/src/pages/tokenize-submit/TokenizeResult.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from 'react'
 import HSButton from '../../components/HSButton'
 import { SectionLoading } from '../../components/Spinner'
 import { Market } from '../../const'
+import { useAddToWalletList } from '../../hooks/useAddToWalletList'
 
 interface TokenizeResultProps {
   isLoading: boolean
@@ -18,39 +19,18 @@ const TokenizeResult: React.FC<TokenizeResultProps> = ({
   market,
   tokenSymbol
 }) => {
-  const addToWalletList = useCallback(async () => {
-    const tokenDecimals = 18
+  const { addToWalletList } = useAddToWalletList()
 
-    try {
-      if (!window.ethereum) {
-        return
-      }
-
-      window.ethereum.request({
-        method: 'wallet_watchAsset',
-        params: {
-          type: 'ERC20', // Initially only supports ERC20, but eventually more!
-          options: {
-            address: newPropertyAddress, // The address that the token is at.
-            symbol: tokenSymbol, // A ticker symbol or shorthand, up to 5 chars.
-            decimals: tokenDecimals // The number of decimals in the token
-          }
-        }
-      })
-    } catch (error) {
-      console.log(error)
-    }
-  }, [tokenSymbol, newPropertyAddress])
-
-  useEffect(() => {
+  const addToUserWallet = useCallback(async () => {
     if (!newPropertyAddress || (newPropertyAddress && newPropertyAddress === '')) {
       return
     }
+    addToWalletList(tokenSymbol, newPropertyAddress)
+  }, [tokenSymbol, newPropertyAddress, addToWalletList])
 
-    addToWalletList()
-
-    // add to wallet list
-  }, [addToWalletList, newPropertyAddress])
+  useEffect(() => {
+    addToUserWallet()
+  }, [addToUserWallet, newPropertyAddress])
 
   return (
     <>


### PR DESCRIPTION
## Proposed Changes
Add a button on the Property pages so user can easier add property token to wallet list

## Implementation
Separates out code that adds property to wallet list on successful tokenization into a `useAddToWalletList` hook.
Uses that hook in the PropertySummary header.
Cleans up TokenizationResult success to user the hook as well.
