### PR TITLE
prompts wallet to switch network

### DIFF
--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -26,4 +26,11 @@ export const DEPLOYMENTS = {
   polygon_mainnet: 'https://polygon.niwa.xyz'
 }
 
+export const NETWORK_RPC_URLS = {
+  arbitrum_rinkeby: 'https://rinkeby.arbitrum.io/rpc',
+  arbitrum_one: 'https://arb1.arbitrum.io/rpc',
+  polygon_mumbai: 'https://rpc-mumbai.maticvigil.com/',
+  polygon_mainnet: 'https://polygon-rpc.com/'
+}
+
 export const TOKENIZE_STEP_LABELS = ['Select Market', 'Enter Token Details', 'Create Token'] as const

--- a/src/context/walletContext.ts
+++ b/src/context/walletContext.ts
@@ -1,11 +1,13 @@
 import { createContext, Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react'
-import { providers } from 'ethers'
+import { providers, utils } from 'ethers'
 import { UndefinedOr } from '@devprotocol/util-ts'
 import {
   connectedNetworkMatchesDeployment,
-  getDeploymentUrlByChainId,
-  infuraEndpoint,
-  isValidNetwork
+  deployedNetworkToChainId,
+  deployedNetworkToReadable,
+  getExplorerUrl,
+  getRpcUrlByChainId,
+  infuraEndpoint
 } from '../utils/utils'
 
 export interface IWallet {
@@ -30,11 +32,58 @@ export function useWalletProviderContext(): IWallet {
   const [ethersProvider, setEthersProvider] = useState<UndefinedOr<providers.Web3Provider>>(undefined)
   const [isValidConnectedNetwork, setIsValidConnectedNetwork] = useState(true)
 
+  // pulled from https://docs.metamask.io/guide/rpc-api.html#usage-with-wallet-switchethereumchain
+  const promptWalletNetworkChange = async (chainId: number) => {
+    console.log('promptWalletNetworkChange: ', chainId)
+    // Check if MetaMask is installed
+    // MetaMask injects the global API into window.ethereum
+    if (window.ethereum) {
+      try {
+        // check if the chain to connect to is installed
+        await window.ethereum.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: `${utils.hexValue(deployedNetworkToChainId())}` }] // chainId must be in hexadecimal numbers
+        })
+      } catch (error: any) {
+        console.log('error: ', error)
+        // This error code indicates that the chain has not been added to MetaMask
+        // if it is not, then install it into the user MetaMask
+        if (error.code === 4902) {
+          try {
+            await window.ethereum.request({
+              method: 'wallet_addEthereumChain',
+              params: [
+                {
+                  chainId: utils.hexValue(deployedNetworkToChainId()),
+                  chainName: deployedNetworkToReadable(),
+                  nativeCurrency: {
+                    name: chainId === 421611 || chainId === 42161 ? 'Ether' : 'Matic',
+                    symbol: chainId === 421611 || chainId === 42161 ? 'ETH' : 'MATIC', // 2-6 characters long
+                    decimals: 18
+                  },
+                  rpcUrls: [getRpcUrlByChainId(chainId)],
+                  blockExplorerUrls: [getExplorerUrl()]
+                }
+              ]
+            })
+          } catch (addError) {
+            console.error(addError)
+          }
+        }
+        console.error(error)
+      }
+    } else {
+      // if no window.ethereum then MetaMask is not installed
+      console.error('metamask not installed')
+    }
+  }
+
   useEffect(() => {
     if (!ethersProvider) {
       return
     }
     ;(async () => {
+      setIsValidConnectedNetwork(false)
       const chainId = (await ethersProvider.getNetwork()).chainId
       console.log('chain id is: ', chainId)
       if (connectedNetworkMatchesDeployment(chainId)) {
@@ -42,23 +91,25 @@ export function useWalletProviderContext(): IWallet {
         return
       }
 
-      // completely invalid network. No deployment.
-      // block wallet and all activities
-      if (!isValidNetwork(chainId)) {
-        setIsValidConnectedNetwork(false)
-        return
-      }
+      promptWalletNetworkChange(chainId)
 
-      // Invalid network BUT deployment may exist
-      // Redirect to correct deployment if possible
-      const redirectTo = getDeploymentUrlByChainId(chainId)
-      if (!redirectTo) {
-        setIsValidConnectedNetwork(false)
-        return
-      }
+      // // completely invalid network. No deployment.
+      // // block wallet and all activities
+      // if (!isValidNetwork(chainId)) {
+      //   setIsValidConnectedNetwork(false)
+      //   return
+      // }
 
-      window.location.replace(redirectTo)
-      return
+      // // Invalid network BUT deployment may exist
+      // // Redirect to correct deployment if possible
+      // const redirectTo = getDeploymentUrlByChainId(chainId)
+      // if (!redirectTo) {
+      //   setIsValidConnectedNetwork(false)
+      //   return
+      // }
+
+      // window.location.replace(redirectTo)
+      // return
     })()
   }, [ethersProvider])
 

--- a/src/context/walletContext.ts
+++ b/src/context/walletContext.ts
@@ -85,31 +85,12 @@ export function useWalletProviderContext(): IWallet {
     ;(async () => {
       setIsValidConnectedNetwork(false)
       const chainId = (await ethersProvider.getNetwork()).chainId
-      console.log('chain id is: ', chainId)
       if (connectedNetworkMatchesDeployment(chainId)) {
         setIsValidConnectedNetwork(true)
         return
       }
 
       promptWalletNetworkChange(chainId)
-
-      // // completely invalid network. No deployment.
-      // // block wallet and all activities
-      // if (!isValidNetwork(chainId)) {
-      //   setIsValidConnectedNetwork(false)
-      //   return
-      // }
-
-      // // Invalid network BUT deployment may exist
-      // // Redirect to correct deployment if possible
-      // const redirectTo = getDeploymentUrlByChainId(chainId)
-      // if (!redirectTo) {
-      //   setIsValidConnectedNetwork(false)
-      //   return
-      // }
-
-      // window.location.replace(redirectTo)
-      // return
     })()
   }, [ethersProvider])
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { addresses, marketAddresses } from '@devprotocol/dev-kit'
 import { UndefinedOr } from '@devprotocol/util-ts'
 import { ethers, providers, utils } from 'ethers'
-import { DEPLOYMENTS, Market } from '../const'
+import { DEPLOYMENTS, Market, NETWORK_RPC_URLS } from '../const'
 import { NetworkName } from '@devprotocol/khaos-core'
 import { createPropertyContract } from '@devprotocol/dev-kit/l2'
 import { AssetProperty } from '../hooks/useMetrics'
@@ -179,6 +179,19 @@ export const deployedNetworkToReadable = () => {
   }
 }
 
+export const deployedNetworkToChainId = () => {
+  switch (import.meta.env.VITE_L2_NETWORK) {
+    case 'arbitrum-one':
+      return 42161
+    case 'arbitrum-rinkeby':
+      return 421611
+    case 'polygon-mainnet':
+      return 137
+    case 'polygon-mumbai':
+      return 80001
+  }
+}
+
 export const crunchAddress = (address: string) => {
   return address.length > 6
     ? `${address.substring(2, 6)}...${address.substring(address.length - 4, address.length)}`
@@ -195,6 +208,19 @@ export const getExplorerUrl = () => {
       return 'https://polygonscan.com'
     case 'polygon-mumbai':
       return 'https://mumbai.polygonscan.com'
+  }
+}
+
+export const getRpcUrlByChainId = (chainId: number) => {
+  switch (chainId) {
+    case 421611: // arbitrum testnet
+      return NETWORK_RPC_URLS.arbitrum_rinkeby
+    case 42161: // arbitrum mainnet
+      return NETWORK_RPC_URLS.arbitrum_one
+    case 137: // polygon mainnet
+      return NETWORK_RPC_URLS.polygon_mainnet
+    case 80001: // polygon testnet
+      return NETWORK_RPC_URLS.polygon_mumbai
   }
 }
 


### PR DESCRIPTION
## Proposed Changes
Instead of custom redirect, use https://docs.metamask.io/guide/rpc-api.html#usage-with-wallet-switchethereumchain to prompt wallet to switch chain

## Implementation
Strips out code that manually redirects to appropriate wallet.
Instead, prompts user wallet to switch network.

closes #236 